### PR TITLE
Allow no additional files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,6 @@ All notable changes to **basinex** will be documented in this file.
 ### Bugfixes
 - solved yaml warnings
 
-[Unreleased]: https://github.com/mhm-ufz/basinex/compare/v0.1...HEAD
-[0.2]: https://github.com/mhm-ufz/basinex/compare/v0.1...v0.2
-[0.1]: https://github.com/mhm-ufz/basinex/releases/tag/0.1
+[Unreleased]: https://github.com/mhm-ufz/basinex/compare/v0.2.0...HEAD
+[0.2]: https://github.com/mhm-ufz/basinex/compare/v0.1.0...v0.2.0
+[0.1]: https://github.com/mhm-ufz/basinex/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to **basinex** will be documented in this file.
 
+## [0.2] - 2022-07
+
+### Enhancements
+- updated `report.out` with catchment area comparison and adjusted x, y of gauges ([#3](https://github.com/mhm-ufz/basinex/pull/3))
+- `mask`, `gauge`, `gridfiles` and `ncfiles` are truly optional now ([#4](https://github.com/mhm-ufz/basinex/pull/4))
+
+### Bugfixes
+- `netcdf4` version needs to be `<1.6`, so we added a restriction to `setup.cfg` ([#3](https://github.com/mhm-ufz/basinex/pull/3))
+
 
 ## [0.1] - 2022-02
 

--- a/src/basinex/main.py
+++ b/src/basinex/main.py
@@ -224,12 +224,12 @@ def main(config, gauges):
             logging.debug("reding gauge file")
             mask = gridBasinMask(gauge)
 
-        for fdict in config["gridfiles"]:
+        for fdict in config.get("gridfiles", []):
             logging.debug("processing: %s", fdict["fname"])
             griddata = ga.fromfile(fdict["fname"]).shrink(**mask.bbox)
             filedict[GridFile(**fdict)] = maskData(griddata, mask)
 
-        for fdict in config["ncfiles"]:
+        for fdict in config.get("ncfiles", []):
             logging.debug("processing: %s", fdict["fname"])
             fitem = NcFile(**fdict)
             ncdata = NcDimDataset(

--- a/src/basinex/main.py
+++ b/src/basinex/main.py
@@ -164,6 +164,7 @@ def sameExtend(fobjs):
 def writeReport(bpath, mask, scaling_factor, gauge):
     size = (np.sum(~mask.mask) * np.prod(np.abs(mask.cellsize))) * scaling_factor**2
     error_size = (size - gauge.size) / gauge.size * 100
+    Path(bpath).mkdir(exist_ok=True, parents=True)
     with open(os.path.join(bpath, "report.out"), "w") as f:
         f.write("calculated_catchment_size: {:}\n".format(size))
         f.write("input_catchment_size     : {:}\n".format(gauge.size))
@@ -251,14 +252,15 @@ def main(config, gauges):
             )
             filedict[fitem] = mask
 
-        logging.debug("finding common extend")
-        bbox = commonBbox(tuple(filedict.values()))
+        if filedict:
+            logging.debug("finding common extend")
+            bbox = commonBbox(tuple(filedict.values()))
 
-        logging.debug("enlarging data to common extend")
-        filedict = enlargeFiles(filedict, bbox)
+            logging.debug("enlarging data to common extend")
+            filedict = enlargeFiles(filedict, bbox)
 
-        if not sameExtend(tuple(filedict.values())):
-            raise RuntimeError("incompatible cellsizes")
+            if not sameExtend(tuple(filedict.values())):
+                raise RuntimeError("incompatible cellsizes")
 
         bpath = os.path.join(config["outpath"], gauge.id)
         writeFiles(bpath, filedict)


### PR DESCRIPTION
`mask`, `gauge`, `gridfiles` and `ncfiles` were stated as optional in the documentation, but basinex threw an error if they were not given.
This pull request fixes this.