### PR TITLE
add multi-gauge facilitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ ncfiles:
     - `path`:    path to the mask file
     - `varname`: name of the mask variable (optional, only needed if the mask is stored in a netcdf file)
 - `latitude-size-correction: False` - **Optional**:
-  perform a latitude correction for the given basin size (default: False)
+  perform a latitude correction for the basin size of a given gauge (default: False)
   - `AREA = N_cells * res_x * ( cos(LAT) * res_y ) * scaling factor^2`
 - `matching:` - **Required**: gauge matching parameters
   - **Note**:
     The gauge matching is based on the flowaccumulation data. The value for
     any given cell in the flowaccumulation grid is interpreted as the size
-    [in cells] of a river basin drainig into the respective cell.
+    [in cells] of a river basin draining into the respective cell.
     During gauge matching the flowaccumulation grid is searched for a cell
     with a corresponding basin size close to the given gauge basin size. The
     search radius will be increased succesively and can be limited to a

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The [mHM](https://mhm-ufz.org/) basin extractor. Extract basins for given gaugin
 ## Dependencies
 
 - numpy v1.14.5 or later
+- pandas
 - netCDF4
 - GDAL
 - pyyaml
@@ -36,7 +37,7 @@ To get a recent version of GDAL, you can use the ppa of [ubuntugis](https://laun
 sudo add-apt-repository ppa:ubuntugis/ppa
 sudo apt-get update
 sudo apt install gdal-bin libgdal-dev
-pip install wheel numpy
+pip install wheel numpy pandas
 pip install GDAL==$(gdal-config --version)
 ```
 
@@ -44,7 +45,7 @@ pip install GDAL==$(gdal-config --version)
 GDAL can be installed with [homebrew](https://formulae.brew.sh/formula/gdal):
 ```
 brew install gdal
-pip install wheel numpy
+pip install wheel numpy pandas
 pip install GDAL==$(gdal-config --version)
 ```
 
@@ -60,7 +61,7 @@ pipwin install gdal
 It is best to use basinex with conda to have gdal and NetCDF installed properly.
 To use the development version of basinex, download this repository and do the following in your conda environment:
 
-    conda install -y gdal netcdf4 pyyaml cxx-compiler
+    conda install -y gdal netcdf4 pyyaml cxx-compiler pandas
     pip install .
 
 Then you can execute `basinex` in that conda environment.

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ install_requires =
     pyyaml
     gdal
     netcdf4<1.6
+    pandas
 python_requires = >=3.6
 zip_safe = False
 

--- a/src/basinex/gauges.py
+++ b/src/basinex/gauges.py
@@ -10,9 +10,9 @@ class Gauge(object):
         self, id, y=None, x=None, size=None, path=None, varname=None, lat_fix=False
     ):
         self.id = id
-        self.y = y
-        self.x = x
-        self.size = float(size) / np.cos(np.deg2rad(float(y))) if lat_fix else size
+        self.y = float(y)
+        self.x = float(x)
+        self.size = float(size) / np.cos(np.deg2rad(self.y)) if lat_fix else float(size)
         self.path = path
         self.varname = varname
 
@@ -66,9 +66,9 @@ def matchFlowacc(gauge, facc, max_distance, max_error, scaling_factor=1):
           to convert from map units to km^2 of the catchment area
     """
     # print "gauge before:", gauge.y, gauge.x
-    y = float(gauge.y)
-    x = float(gauge.x)
-    size = float(gauge.size)
+    y = gauge.y
+    x = gauge.x
+    size = gauge.size
     bbox = {
         "ymin": y - max_distance,
         "ymax": y + max_distance,

--- a/src/basinex/gauges.py
+++ b/src/basinex/gauges.py
@@ -99,4 +99,6 @@ def matchFlowacc(gauge, facc, max_distance, max_error, scaling_factor=1):
 
         # the cell cordinates
         y, x = grid.coordinatesOf(river_cells_y[nn], river_cells_x[nn])
-        return Gauge(id=gauge.id, y=y, x=x, size=size)
+        return Gauge(id=gauge.id, y=y, x=x, size=grid.data[river_cells_y[nn], river_cells_x[nn]]), error
+    else:
+        return None, error

--- a/src/basinex/geoarray/spatial.py
+++ b/src/basinex/geoarray/spatial.py
@@ -4,6 +4,9 @@ from math import ceil, floor
 
 import numpy as np
 
+# precision for rounding to avoid numerical instabilities
+PRECISION = 10
+
 
 class SpatialMixin(object):
     def trim(self):
@@ -83,10 +86,10 @@ class SpatialMixin(object):
         }
 
         cellsize = [float(abs(cs)) for cs in self.cellsize]
-        top = floor((self.bbox["ymax"] - bbox["ymax"]) / cellsize[0])
-        left = floor((bbox["xmin"] - self.bbox["xmin"]) / cellsize[1])
-        bottom = floor((bbox["ymin"] - self.bbox["ymin"]) / cellsize[0])
-        right = floor((self.bbox["xmax"] - bbox["xmax"]) / cellsize[1])
+        top = floor(round((self.bbox["ymax"] - bbox["ymax"]) / cellsize[0], PRECISION))
+        left = floor(round((bbox["xmin"] - self.bbox["xmin"]) / cellsize[1], PRECISION))
+        bottom = floor(round((bbox["ymin"] - self.bbox["ymin"]) / cellsize[0], PRECISION))
+        right = floor(round((self.bbox["xmax"] - bbox["xmax"]) / cellsize[1], PRECISION))
 
         return self.removeCells(
             max(top, 0), max(left, 0), max(bottom, 0), max(right, 0)
@@ -175,10 +178,10 @@ class SpatialMixin(object):
 
         cellsize = [float(abs(cs)) for cs in self.cellsize]
 
-        top = ceil((bbox["ymax"] - self.bbox["ymax"]) / cellsize[0])
-        left = ceil((self.bbox["xmin"] - bbox["xmin"]) / cellsize[1])
-        bottom = ceil((self.bbox["ymin"] - bbox["ymin"]) / cellsize[0])
-        right = ceil((bbox["xmax"] - self.bbox["xmax"]) / cellsize[1])
+        top = ceil(round((bbox["ymax"] - self.bbox["ymax"]) / cellsize[0], PRECISION))
+        left = ceil(round((self.bbox["xmin"] - bbox["xmin"]) / cellsize[1], PRECISION))
+        bottom = ceil(round((self.bbox["ymin"] - bbox["ymin"]) / cellsize[0], PRECISION))
+        right = ceil(round((bbox["xmax"] - self.bbox["xmax"]) / cellsize[1], PRECISION))
 
         return self.addCells(max(top, 0), max(left, 0), max(bottom, 0), max(right, 0))
 

--- a/src/basinex/geoarray/wrapper.py
+++ b/src/basinex/geoarray/wrapper.py
@@ -190,7 +190,7 @@ def full(shape, value, dtype=np.float64, *args, **kwargs):
     Arguments
     ---------
     shape        : tuple          # shape of the returned grid
-    fill_value   : scalar         # fille value
+    fill_value   : scalar         # fill value
 
     Optional Arguments
     ------------------

--- a/src/basinex/main.py
+++ b/src/basinex/main.py
@@ -153,7 +153,7 @@ def gaugeGrid(grid_template, gauge):
     return out
 
 
-def sameExtend(fobjs):
+def sameExtent(fobjs):
     bbox = commonBbox(fobjs)
     for fobj in fobjs:
         if fobj.bbox != bbox:
@@ -227,7 +227,7 @@ def main(config, gauges):
                 filedict[fitem] = maskData(gaugefile, mask)
 
         else:
-            logging.debug("reding gauge file")
+            logging.debug("reading gauge file")
             mask = gridBasinMask(gauge)
 
         for fdict in config.get("gridfiles", []):
@@ -258,13 +258,13 @@ def main(config, gauges):
             filedict[fitem] = mask
 
         if filedict:
-            logging.debug("finding common extend")
+            logging.debug("finding common extent")
             bbox = commonBbox(tuple(filedict.values()))
 
-            logging.debug("enlarging data to common extend")
+            logging.debug("enlarging data to common extent")
             filedict = enlargeFiles(filedict, bbox)
 
-            if not sameExtend(tuple(filedict.values())):
+            if not sameExtent(tuple(filedict.values())):
                 raise RuntimeError("incompatible cellsizes")
 
         bpath = os.path.join(config["outpath"], gauge.id)

--- a/src/basinex/main.py
+++ b/src/basinex/main.py
@@ -170,8 +170,8 @@ def sameExtent(fobjs):
     return True
 
 
-def writeReport(bpath, updated_gauge, gauge, error, do_write=False):
-    if do_write:        
+def writeReport(bpath, updated_gauge, gauge, error):
+    if logging.DEBUG >= logging.root.level:        
         Path(bpath).mkdir(exist_ok=True, parents=True)
         with open(os.path.join(bpath, "report.out"), "w") as f:
             f.write("error_catchment_size (%) : {:}\n".format(error))

--- a/src/basinex/main.py
+++ b/src/basinex/main.py
@@ -174,7 +174,7 @@ def writeReport(bpath, mask, scaling_factor, gauge):
 
 
 def maskData(data, mask):
-    if all(x == y for x, y in zip(mask.cellsize, data.cellsize)):
+    if all(np.isclose(x, y) for x, y in zip(mask.cellsize, data.cellsize)):
         return data.setMask(mask.mask)
 
     enlarged_mask = mask.enlarge(**data.bbox).astype(float)

--- a/src/basinex/main.py
+++ b/src/basinex/main.py
@@ -186,6 +186,9 @@ def maskData(data, mask):
 
 def main(config, gauges):
 
+    flowacc = None
+    flowdir = None
+
     for gauge in gauges:
         logging.info("processing gauge: %s", gauge.id)
 
@@ -194,11 +197,13 @@ def main(config, gauges):
         if not gauge.path:
 
             # create mask if not given
-            logging.debug("reading flow accumulation")
-            flowacc = ga.fromfile(config["flowacc"]).astype(np.int32)
+            if flowacc is None:
+                logging.debug("reading flow accumulation")
+                flowacc = ga.fromfile(config["flowacc"]).astype(np.int32)
 
-            logging.debug("reading flow direction")
-            flowdir = ga.fromfile(config["flowdir"]).astype(np.int32)
+            if flowdir is None:
+                logging.debug("reading flow direction")
+                flowdir = ga.fromfile(config["flowdir"]).astype(np.int32)
 
             if gauge.size:
                 logging.debug("moving gauge to streamflow")

--- a/src/basinex/main.py
+++ b/src/basinex/main.py
@@ -148,6 +148,7 @@ def commonBbox(fobjs):
 def gaugeGrid(grid_template, gauge, out_in=None):
     if out_in is None:
         out = ga.full_like(grid_template, grid_template.fill_value)
+        out._fobj = None
     else:
         out = out_in
     idx = out.indexOf(gauge.y, gauge.x)


### PR DESCRIPTION
implemented some new features
- caching of input arrays (flowdirection and flow accumulation), was read for each gauge again previously
- fixed some bugs preventing correct write out of ASCII files (setting the geoarray._fobj attribute to None)
- added pandas dependency to create csv table of aggregated reports
- added warning if gauge is reattributed to same id in flow dir network
- added mode to create a global (combined) idgauges.asc file instead of one per gauge